### PR TITLE
moved evm warp creation out of example

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,7 +44,7 @@ evm_networks:
       symbol: 'ETH'
       decimals: 18
     mailbox_address: "0x123..."
-    multisig_ism_factory_addres: "0x123..."
+    multisig_ism_factory_address: "0x123..."
 
 
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -32,6 +32,22 @@ networks:
       denom: 'untrn'
     domain: 1302
 
+# Networks that already have hyperlane deployments
+# but might require new warp route connections
+evm_networks:
+  - name: 'mantasepolia'
+    chain_id: 3441006
+    rpc_endpoint: "http://localhost:8545"
+    network: 'sepolia'
+    nativeCurrency:
+      name: 'Sepolia Ether'
+      symbol: 'ETH'
+      decimals: 18
+    mailbox_address: "0x123..."
+    multisig_ism_factory_addres: "0x123..."
+
+
+
 signer: deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 
 deploy:

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -153,7 +153,7 @@ import {
         functionName: 'getAddress',
         args: [[ismValidatorAddress], Number(ismThreshold)],
       });
-      console.log(`Deploying multisigIsm at "${multisigIsmAddr.green}"...`);
+      console.log(`\nDeploying multisigIsm at "${multisigIsmAddr.green}"...`);
     
       {
         const tx = await exec.writeContract({
@@ -182,11 +182,10 @@ import {
       logTx('Set ism for warp route', tx);
       await query.waitForTransactionReceipt({ hash: tx });
     }
-  
-    console.log('== Done! ==');
-  
-    console.log({
-      hypErc20: hypErc20Addr,
-    });
+    
+    console.log(`\nWarp ERC20: ${hypErc20Addr.blue}`);
+    if (warpIsmAddress !== undefined) {
+      console.log(`ISM Address: ${warpIsmAddress.blue}`);
+    }
   }
   

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -52,6 +52,11 @@ import {
       '--ism-validator-address <ism-validator-address>', 
       'Validator address on the ism',
     )
+    .option(
+      '--ism-threshold <ism-threshold>', 
+      'Threshold for the number of validators in the ISM',
+      "1",
+    )
     .action(deployWarpRoute);
   
   export { evmCmd };
@@ -63,6 +68,7 @@ import {
     createNewIsm?: boolean,
     warpIsmAddress?: `0x${string}`,
     ismValidatorAddress?: `0x${string}`,
+    ismThreshold?: number,
   };
   
   async function deployWarpRoute({
@@ -72,6 +78,7 @@ import {
     createNewIsm,
     warpIsmAddress,
     ismValidatorAddress,
+    ismThreshold,
   }: DeployWarpRouteArgs) {
     const { signer } = config;
     const evmNetwork = getEvmNetwork(evmNetworkName)
@@ -144,7 +151,7 @@ import {
         abi: StaticMessageIdMultisigIsmFactory__factory.abi,
         address: evmNetwork.multisig_ism_factory_address,
         functionName: 'getAddress',
-        args: [[ismValidatorAddress], 1],
+        args: [[ismValidatorAddress], Number(ismThreshold)],
       });
       console.log(`Deploying multisigIsm at "${multisigIsmAddr.green}"...`);
     
@@ -153,7 +160,7 @@ import {
           abi: StaticMessageIdMultisigIsmFactory__factory.abi,
           address: evmNetwork.multisig_ism_factory_address,
           functionName: 'deploy',
-          args: [[ismValidatorAddress], 1],
+          args: [[ismValidatorAddress], Number(ismThreshold)],
         });
         logTx('Deploy multisig ism', tx);
         await query.waitForTransactionReceipt({ hash: tx });

--- a/script/commands/evm.ts
+++ b/script/commands/evm.ts
@@ -1,0 +1,193 @@
+import { 
+    HypERC20__factory, 
+    StaticMessageIdMultisigIsmFactory__factory,
+  } from '@hyperlane-xyz/core';
+  import { Command, Option} from 'commander';
+  import { isAddress } from 'viem';
+  
+  import { HYP_MAILBOX, HYP_MULTSIG_ISM_FACTORY } from './constants';
+  import { CONTAINER, Dependencies } from './ioc';
+  import {
+    expectNextContractAddr,
+    extractByte32AddrFromBech32,
+    logTx,
+  } from './utils';
+  
+  const warpCmd = new Command('warp');
+  
+  warpCmd.command('deploy')
+    .option(
+      '--contract-name <contract-name>', 
+      'Warp contract name e.g. Hyperlane Bridged TIA',
+      'Hyperlane Bridged Osmo'
+    )
+    .option(
+      '--asset-name <asset-name>', 
+      'Warp route asset name e.g. TIA',
+      'TIA'
+    )
+    .option(
+      '--create-new-ism', 
+      'Option to create a new ISM for the the warp route',
+      false
+    )
+    .option(
+      '--warp-ism-address <warp-ism-address>', 
+      'ISM to set on the warp route recipient'
+    )
+    .option(
+      '--ism-validator-address <ism-validator-address>', 
+      'Validator address on the ism',
+    )
+    .action(deployWarpRoute);
+  
+  warpCmd
+    .command('link')
+    .argument('<warp>', 'address of warp route')
+    .argument('<domain>', 'destination domain to set')
+    .argument('<route>', 'destination address to set')
+    .action(linkWarpRoute);
+  
+  warpCmd
+    .command('transfer')
+    .argument('<warp>', 'address of warp route')
+    .argument('<domain>', 'destination domain to transfer')
+    .argument('<to>', 'address to transfer')
+    .action(transferWarpRoute);
+  
+  export { warpCmd };
+  
+  type DeployWarpRouteArgs = {
+    contractName: string,
+    assetName: string,
+    createNewIsm?: boolean,
+    warpIsmAddress?: `0x${string}`,
+    ismValidatorAddress?: `0x${string}`,
+  };
+  
+  async function deployWarpRoute({
+    contractName,
+    assetName,
+    createNewIsm,
+    warpIsmAddress,
+    ismValidatorAddress,
+  }: DeployWarpRouteArgs) {
+    const {
+      account,
+      provider: { query, exec },
+    } = CONTAINER.get(Dependencies);
+  
+    if (createNewIsm && warpIsmAddress !== undefined) {
+      throw new Error("invalid options: cannot create a new ISM and pass a custom ISM address at the same time")
+    }
+  
+    // deploy hyp erc20 (implementation)
+    const hypErc20Addr = await expectNextContractAddr(query, account);
+    console.log(`Deploying HypERC20 at "${hypErc20Addr.green}"...`);
+  
+    {
+      const tx = await exec.deployContract({
+        abi: HypERC20__factory.abi,
+        bytecode: HypERC20__factory.bytecode,
+        args: [6, HYP_MAILBOX],
+      });
+      logTx('Deploying HypERC20', tx);
+      await query.waitForTransactionReceipt({ hash: tx });
+    }
+  
+    {
+      const tx = await exec.writeContract({
+        abi: HypERC20__factory.abi,
+        address: hypErc20Addr,
+        functionName: 'initialize',
+        args: [0n, contractName ? contractName : 'Hyperlane Bridged OSMO', assetName ? assetName : 'OSMO'],
+      });
+      logTx('Initialize HypERC20', tx);
+      await query.waitForTransactionReceipt({ hash: tx });
+    }
+  
+    // If the option was specifed to create a new ISM, deploy the multisig ISM contract
+    if (createNewIsm) {
+      ismValidatorAddress = ismValidatorAddress ? ismValidatorAddress : account.address
+  
+      const multisigIsmAddr = await query.readContract({
+        abi: StaticMessageIdMultisigIsmFactory__factory.abi,
+        address: HYP_MULTSIG_ISM_FACTORY,
+        functionName: 'getAddress',
+        args: [[ismValidatorAddress], 1],
+      });
+      console.log(`Deploying multisigIsm at "${multisigIsmAddr.green}"...`);
+    
+      {
+        const tx = await exec.writeContract({
+          abi: StaticMessageIdMultisigIsmFactory__factory.abi,
+          address: HYP_MULTSIG_ISM_FACTORY,
+          functionName: 'deploy',
+          args: [[ismValidatorAddress], 1],
+        });
+        logTx('Deploy multisig ism', tx);
+        await query.waitForTransactionReceipt({ hash: tx });
+      }
+  
+      warpIsmAddress = multisigIsmAddr
+    }
+    
+    // If a custom ISM address was specified or if a new ISM was created,
+    // register that address in the warp contract
+    // Otherwise, the default ISM will be used
+    if (warpIsmAddress !== undefined) {
+      const tx = await exec.writeContract({
+        abi: HypERC20__factory.abi,
+        address: hypErc20Addr,
+        functionName: 'setInterchainSecurityModule',
+        args: [warpIsmAddress],
+      });
+      logTx('Set ism for warp route', tx);
+      await query.waitForTransactionReceipt({ hash: tx });
+    }
+  
+    console.log('== Done! ==');
+  
+    console.log({
+      hypErc20: hypErc20Addr,
+    });
+  }
+  
+  async function linkWarpRoute(warp: string, domain: string, route: string) {
+    const {
+      provider: { exec, query },
+    } = CONTAINER.get(Dependencies);
+  
+    if (!isAddress(warp)) throw new Error('Invalid warp address');
+  
+    const tx = await exec.writeContract({
+      abi: HypERC20__factory.abi,
+      address: warp,
+      functionName: 'enrollRemoteRouter',
+      args: [parseInt(domain), `0x${extractByte32AddrFromBech32(route)}`],
+    });
+    logTx(`Linking warp route with external chain ${domain}`, tx);
+    await query.waitForTransactionReceipt({ hash: tx });
+  }
+  
+  async function transferWarpRoute(warp: string, domain: string, to: string) {
+    const {
+      provider: { exec, query },
+    } = CONTAINER.get(Dependencies);
+  
+    if (!isAddress(warp)) throw new Error('Invalid warp address');
+  
+    const tx = await exec.writeContract({
+      abi: HypERC20__factory.abi,
+      address: warp,
+      functionName: 'transferRemote',
+      args: [
+        parseInt(domain),
+        `0x${extractByte32AddrFromBech32(to)}`,
+        1_000_000n,
+      ],
+    });
+    logTx(`Transferring warp route with external chain ${domain}`, tx);
+    await query.waitForTransactionReceipt({ hash: tx });
+  }
+  

--- a/script/commands/index.ts
+++ b/script/commands/index.ts
@@ -5,3 +5,4 @@ export { migrateCmd } from './migrate';
 export { uploadCmd } from './upload';
 export { walletCmd } from './wallet';
 export { warpCmd } from './warp';
+export { evmCmd } from './evm';

--- a/script/index.ts
+++ b/script/index.ts
@@ -6,6 +6,7 @@ import { version } from '../package.json';
 import {
   contextCmd,
   contractCmd,
+  evmCmd,
   deployCmd,
   migrateCmd,
   uploadCmd,
@@ -41,6 +42,7 @@ cli.addCommand(migrateCmd);
 cli.addCommand(uploadCmd);
 cli.addCommand(walletCmd);
 cli.addCommand(warpCmd);
+cli.addCommand(evmCmd);
 
 cli.parseAsync(process.argv).catch(console.error);
 

--- a/script/shared/config.ts
+++ b/script/shared/config.ts
@@ -116,6 +116,20 @@ export type Config = {
     tm_version?: '34' | '37' | '38';
   }[];
 
+  evmNetworks: {
+    name: string;
+    chain_id: number;
+    rpc_endpoint: string;
+    network: string;
+    nativeCurrency: {
+      name: string;
+      symbol: string;
+      decimals: number;
+    };
+    mailboxAddress: `0x${string}`;
+    multisigIsmFactoryAddress: `0x${string}`;
+  }[];
+
   signer: string;
 
   deploy: {
@@ -145,6 +159,13 @@ export const getNetwork = (networkId: string): Config['networks'][number] => {
 };
 
 export const config = yaml.load(readFileSync(path, 'utf-8')) as Config;
+
+export const getEvmNetwork = (networkName: string): Config['evmNetworks'][number] => {
+  const ret = config.evmNetworks.find((v) => v.name === networkName);
+  if (!ret)
+    throw new Error(`EVM Network ${networkName} not found in the config file`);
+  return ret;
+}
 
 export async function getSigningClient(
   networkId: string,

--- a/script/shared/config.ts
+++ b/script/shared/config.ts
@@ -116,18 +116,18 @@ export type Config = {
     tm_version?: '34' | '37' | '38';
   }[];
 
-  evmNetworks: {
+  evm_networks: {
     name: string;
     chain_id: number;
     rpc_endpoint: string;
     network: string;
-    nativeCurrency: {
+    native_currency: {
       name: string;
       symbol: string;
       decimals: number;
     };
-    mailboxAddress: `0x${string}`;
-    multisigIsmFactoryAddress: `0x${string}`;
+    mailbox_address: `0x${string}`;
+    multisig_ism_factory_address: `0x${string}`;
   }[];
 
   signer: string;
@@ -160,8 +160,8 @@ export const getNetwork = (networkId: string): Config['networks'][number] => {
 
 export const config = yaml.load(readFileSync(path, 'utf-8')) as Config;
 
-export const getEvmNetwork = (networkName: string): Config['evmNetworks'][number] => {
-  const ret = config.evmNetworks.find((v) => v.name === networkName);
+export const getEvmNetwork = (networkName: string): Config['evm_networks'][number] => {
+  const ret = config.evm_networks.find((v) => v.name === networkName);
   if (!ret)
     throw new Error(`EVM Network ${networkName} not found in the config file`);
   return ret;


### PR DESCRIPTION
Moved the evm creation command outside of the `example` section.

Requires adding some config to `config.yaml` (see example). Command to run is:
```bash
yarn cw-hpl evm deploy-warp \                         
  -n stride-internal-1 \
  --evm-network-name "karaksepolia" \
  --asset-name "TIA.stride-karak" \
  --contract-name "Hyperlane Bridged TIA.stride-karak" \
  --create-new-ism \
  --ism-validator-address 0x72911905cfD144c8B1aeDa39E4D808a6E7B82EeE
```